### PR TITLE
add metadata callout to read apis

### DIFF
--- a/src/fragments/lib-v1/storage/js/download.mdx
+++ b/src/fragments/lib-v1/storage/js/download.mdx
@@ -132,6 +132,40 @@ try {
 }
 ```
 
+<Callout>
+To get the metadata in result for all read apis we have to configure user defined metadata in CORS
+
+Update your bucket's CORS Policy to look like:
+
+```json
+[
+  {
+    "AllowedHeaders": [
+      "*"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD",
+      "PUT",
+      "POST",
+      "DELETE"
+    ],
+    "AllowedOrigins": [
+      "*"
+    ],
+    "ExposeHeaders": [
+      "x-amz-server-side-encryption",
+      "x-amz-request-id",
+      "x-amz-id-2",
+      "ETag",
+      "x-amz-meta-test-key" // user defined metaData
+     ],
+  }
+]
+```
+</Callout>
+
+
 ### Frequently Asked Questions
 
 Users can run into unexpected issues, so we are giving you advance notice in documentation with links to open issues - please vote for what you need, to help the team prioritize.

--- a/src/fragments/lib-v1/storage/js/get-properties.mdx
+++ b/src/fragments/lib-v1/storage/js/get-properties.mdx
@@ -1,23 +1,25 @@
 You can get file properties and metadata without downloading the file using `getProperties` API from `aws-amplify/storage`
 
-```js
+```ts
 import { getProperties } from 'aws-amplify/storage';
 
-async function getFileProperties() {
-  try {
-    const result = await getProperties({
-			key: 'key',
-		});
+try {
+  const result = await getProperties({
+		key: 'key',
+    options: { accessLevel?: 'private' | 'protected' | 'guest' , // defaults to `guest` 
+    targetIdentityId?: string, // id of another user, if `level: protected`
+    }
+	});
     console.log('File Properties ', result);
-  } catch (error) {
-    console.log('Error ', error);
-  }
+} catch (error) {
+  console.log('Error ', error);
 }
+
 ```
 
 The format of the response will look similar to the below example
 
-```js
+```ts
  {
     key : "key",
     contentType: "image/jpeg",
@@ -28,3 +30,36 @@ The format of the response will look similar to the below example
 }
 
 ```
+
+<Callout>
+To get the metadata in result for all read apis we have to configure user defined metadata in CORS
+
+Update your bucket's CORS Policy to look like:
+
+```json
+[
+  {
+    "AllowedHeaders": [
+      "*"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD",
+      "PUT",
+      "POST",
+      "DELETE"
+    ],
+    "AllowedOrigins": [
+      "*"
+    ],
+    "ExposeHeaders": [
+      "x-amz-server-side-encryption",
+      "x-amz-request-id",
+      "x-amz-id-2",
+      "ETag",
+      "x-amz-meta-test-key" // user defined metaData
+     ],
+  }
+]
+```
+</Callout>

--- a/src/fragments/lib-v1/storage/js/get-properties.mdx
+++ b/src/fragments/lib-v1/storage/js/get-properties.mdx
@@ -32,7 +32,7 @@ The format of the response will look similar to the below example
 ```
 
 <Callout>
-To get the metadata in result for all read apis we have to configure user defined metadata in CORS
+To get the metadata in result for all read apis you have to configure user defined metadata in CORS
 
 Update your bucket's CORS Policy to look like:
 
@@ -57,7 +57,7 @@ Update your bucket's CORS Policy to look like:
       "x-amz-request-id",
       "x-amz-id-2",
       "ETag",
-      "x-amz-meta-test-key" // user defined metaData
+      "x-amz-meta-test-owner" // user defined metaData
      ],
   }
 ]


### PR DESCRIPTION
#### Description of changes:
This doc change add additional options to read apis. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
